### PR TITLE
 Prevent navlinks from sending a request to the server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Post-Times
 
 A simple react multi-page blog
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/3e554403-3f68-437f-a076-3bfe3b8cdc41/deploy-status)](https://app.netlify.com/sites/posttimes/deploys)

--- a/docs/pull_request.md
+++ b/docs/pull_request.md
@@ -5,7 +5,7 @@
 - Outlined description of what the pull request does
 
 #### How should this be manually tested?
-  - Clone the repo with `clone https://github.com/bithubph/bithub-fe.git`
+  - Clone the repo with `clone https://github.com/gagofure/posttimes.git`
   - Checkout to branch `pr-branch-name`
   - Install dependencies `yarn install`
   - Run application `yarn start`
@@ -15,7 +15,7 @@
 - You would need npm or yarn to run this application
 
 #### What are the relevant pivotal tracker stories?
-- PT Story link - [#PTID](https://www.pivotaltracker.com/story/show/[PTID])
+- PT Story link - N/A
 
 
 #### Screenshots (if appropriate)

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ class App extends Component {
     return (
       <BrowserRouter>
         <div className="App">
-          <Navbar />s
+          <Navbar />
           <Route exact path='/' component={Home} />
           <Route path='/About' component={About} />
           <Route path='/Contact' component={Contact} />

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,7 +1,5 @@
 import React from 'react';
-// import Home from './components/Home.js';
-// import About from './components/About.js';
-// import Contact from './components/Contact.js';
+import { Link, NavLink } from "react-router-dom";
 
 
 const Navbar = () => {
@@ -12,9 +10,9 @@ const Navbar = () => {
                     <div className="container">
                         <a href="/" className="brand-logo">Post'Times</a>
                         <ul  className="right ">
-                            <li><a href="/">Home </a></li>
-                            <li><a href="/About">About</a></li>
-                            <li><a href="/Contact">Contact </a></li>
+                            <li>< NavLink to="/">Home </NavLink></li>
+                            <li>< Link to="/About">About</Link></li>
+                            <li>< Link to="/Contact">Contact </Link></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
#### What does this PR do?
- This PR Prevent nav links from sending a request to the server 

#### Description of tasks to be completed?
  - Change the `anchor tags` to `Link to` and `NavLink to`
  - Import Link and NavLink from react-router-dom
  - Add netlify badge to read me

#### How should this be manually tested?
  - Clone the repo with `clone https://github.com/gagofure/posttimes.git`
  - Checkout to branch `pr-branch-name`
  - Install dependencies `yarn install`
  - Run application `yarn start`
  - Click on the links on the navbar, you would notice they no longer reload

#### Any background context you want to provide?
- You would need npm or yarn to run this application

#### What are the relevant pivotal tracker stories?
- PT Story link - N/A


#### Screenshots (if appropriate)
add image links or N/A